### PR TITLE
changing build action for android-support-v4.jar from EmbeddedJar to Emb...

### DIFF
--- a/XamarinOffice365.AdalBindings/XamarinOffice365.AdalBindings.csproj
+++ b/XamarinOffice365.AdalBindings/XamarinOffice365.AdalBindings.csproj
@@ -60,7 +60,7 @@
     <EmbeddedJar Include="Jars\classes.jar" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedJar Include="Jars\android-support-v4.jar" />
+    <EmbeddedReferenceJar Include="Jars\android-support-v4.jar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Changing the build action for android-support-v4.jar from EmbeddedJar to   EmbeddedReferenceJar, as per the instructions on this blog post:

http://chakkaradeep.com/index.php/getting-started-with-office-365-apis-and-xamarin-projects/

(Step 3 under Building the Xamarin Bindings Project)

Without this change, the project doesn't build.